### PR TITLE
Add support for partial import within modules

### DIFF
--- a/lib/node-sass-import.js
+++ b/lib/node-sass-import.js
@@ -11,7 +11,7 @@ var opts = {
   pfx: '?(_)'
 };
 
-var buildSassGlob = function(path) {
+var buildSassGlob = function (path) {
   var parsedPath = pathParse(path);
   if (parsedPath.ext === '') {
     parsedPath.ext = opts.exts;
@@ -26,14 +26,14 @@ var resolver = function (url, baseDir, done) {
   resolve(url, {
     basedir: baseDir,
     extensions: [ '.scss', '.sass', '.css' ],
-    pathFilter: function(pkg, absPath, relativePath) {
+    pathFilter: function (pkg, absPath, relativePath) {
       var globbedPath = buildSassGlob(absPath);
       var paths = glob.sync(globbedPath);
       var resolvedPath = paths && paths[0];
       if (resolvedPath) {
         return path.join(path.dirname(relativePath), path.basename(resolvedPath));
       }
-    },
+    }
   }, function (err, file) {
     if (err) throw err;
 

--- a/lib/node-sass-import.js
+++ b/lib/node-sass-import.js
@@ -11,10 +11,29 @@ var opts = {
   pfx: '?(_)'
 };
 
-var resolver = function (url, baseDir, exts, done) {
+var buildSassGlob = function(path) {
+  var parsedPath = pathParse(path);
+  if (parsedPath.ext === '') {
+    parsedPath.ext = opts.exts;
+    parsedPath.base = opts.pfx + parsedPath.base + opts.exts;
+    parsedPath.name = opts.pfx + parsedPath.name;
+  }
+
+  return pathFormat(parsedPath);
+};
+
+var resolver = function (url, baseDir, done) {
   resolve(url, {
     basedir: baseDir,
-    extensions: [ '.scss', '.sass', '.css' ]
+    extensions: [ '.scss', '.sass', '.css' ],
+    pathFilter: function(pkg, absPath, relativePath) {
+      var globbedPath = buildSassGlob(absPath);
+      var paths = glob.sync(globbedPath);
+      var resolvedPath = paths && paths[0];
+      if (resolvedPath) {
+        return path.join(path.dirname(relativePath), path.basename(resolvedPath));
+      }
+    },
   }, function (err, file) {
     if (err) throw err;
 
@@ -26,17 +45,7 @@ var resolver = function (url, baseDir, exts, done) {
 module.exports = function (url, file, done) {
   var baseDir = path.dirname(file);
   var fullPath = path.resolve(baseDir, url);
-  var parsedPath = pathParse(fullPath);
-  var exts = [ '.scss', '.css' ];
-  var formattedPath;
-
-  if (parsedPath.ext === '') {
-    parsedPath.ext = opts.exts;
-    parsedPath.base = opts.pfx + parsedPath.base + opts.exts;
-    parsedPath.name = opts.pfx + parsedPath.name;
-  }
-
-  formattedPath = pathFormat(parsedPath);
+  var formattedPath = buildSassGlob(fullPath);
 
   glob(formattedPath, function (err, urls) {
     if (err) throw err;
@@ -46,17 +55,17 @@ module.exports = function (url, file, done) {
         if (err) throw err;
 
         if (dirs.length === 0) {
-          resolver(url, baseDir, exts, done);
+          resolver(url, baseDir, done);
         }
 
         if (dirs.length === 1) {
-          resolver(dirs[0], baseDir, exts, done);
+          resolver(dirs[0], baseDir, done);
         }
       });
     }
 
     if (urls.length === 1) {
-      resolver(urls[0], baseDir, exts, done);
+      resolver(urls[0], baseDir, done);
     }
 
     if (urls.length > 1) {


### PR DESCRIPTION
This extends support for automatically finding `_partial(.scss|.sass|.css)` format to files inside node_modules e.g.:

```scss
@import 'some_module/partial'; // -> node_modules/some_module/_partial.scss
```

Unfortunately it seems there's a bit of a performance hit, I think coming from the `glob.sync` call in `pathFilter`. In the tests I added in my other PR I found it was around a 30ms difference in total execution time (~190ms average before vs ~220ms average after).