### PR TITLE
Implement glob importing (#9)

### DIFF
--- a/lib/node-sass-import.js
+++ b/lib/node-sass-import.js
@@ -54,7 +54,6 @@ var resolver = function (url, baseDir, done) {
  */
 
 var importify = function (files) {
-  if (files.length === 0 ) console.trace();
   if (files.length === 1) {
     return { file: files[0] };
   } else {
@@ -101,7 +100,7 @@ module.exports = function (url, file, done) {
     async.parallel(
       urls.map(function (url) {
         return function (callback) {
-          resolver(url, baseDir, callback)
+          resolver(url, baseDir, callback);
         };
       })
     , function (err, filenames) {

--- a/lib/node-sass-import.js
+++ b/lib/node-sass-import.js
@@ -5,6 +5,7 @@ var resolve = require('resolve');
 var glob = require('glob');
 var pathParse = require('path-parse');
 var pathFormat = require('path-format');
+var async = require('async');
 
 var opts = {
   exts: '.@(sa|c|sc)ss',
@@ -22,6 +23,11 @@ var buildSassGlob = function (path) {
   return pathFormat(parsedPath);
 };
 
+/**
+ * Resolves `url` and calls `done(error, null)` when done.
+ * Note that the `done()` function args don't match what node-sass expects.
+ */
+
 var resolver = function (url, baseDir, done) {
   resolve(url, {
     basedir: baseDir,
@@ -35,12 +41,29 @@ var resolver = function (url, baseDir, done) {
       }
     }
   }, function (err, file) {
-    if (err) throw err;
+    if (err) return done(err);
 
     // Strip the extension so .css gets evaluated properly as .scss
     file = file.replace(/\.(sa|sc|c)ss$/, '');
-    done({ file: file });
+    done(null, file);
   });
+};
+
+/**
+ * Builds `{file}` or `{contents}` (as node-sass expects) from a list of files.
+ */
+
+var importify = function (files) {
+  if (files.length === 0 ) console.trace();
+  if (files.length === 1) {
+    return { file: files[0] };
+  } else {
+    var contents = files.map(function (fname) {
+      return '@import ' + JSON.stringify(fname) + ';';
+    }).join('\n');
+
+    return { contents: contents };
+  }
 };
 
 module.exports = function (url, file, done) {
@@ -56,22 +79,34 @@ module.exports = function (url, file, done) {
         if (err) throw err;
 
         if (dirs.length === 0) {
-          resolver(url, baseDir, done);
+          resolver(url, baseDir, function (err, results) {
+            if (err) throw err;
+            done(importify([results]));
+          });
         }
 
         if (dirs.length === 1) {
-          resolver(dirs[0], baseDir, done);
+          resolver(dirs[0], baseDir, function (err, results) {
+            if (err) throw err;
+            done(importify([results]));
+          });
         }
       });
     }
 
-    if (urls.length === 1) {
-      resolver(urls[0], baseDir, done);
-    }
+    if (urls.length === 0) return;
 
-    if (urls.length > 1) {
-      console.log(urls);
-      throw new Error('Resolve conflicting files');
-    }
+    // Resolve all of `urls` through resolver(); then compile them into
+    // '@import' statements.
+    async.parallel(
+      urls.map(function (url) {
+        return function (callback) {
+          resolver(url, baseDir, callback)
+        };
+      })
+    , function (err, filenames) {
+      if (err) throw err;
+      done(importify(filenames));
+    });
   });
 };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "importer"
   ],
   "dependencies": {
+    "async": "2.0.1",
     "glob": "^6.0.4",
     "path-format": "^1.2.1",
     "path-parse": "^1.0.5",

--- a/test/fixtures/glob.scss
+++ b/test/fixtures/glob.scss
@@ -1,0 +1,1 @@
+@import './glob/*';

--- a/test/fixtures/glob/one.scss
+++ b/test/fixtures/glob/one.scss
@@ -1,0 +1,1 @@
+div.one { color: blue; }

--- a/test/fixtures/glob/two.scss
+++ b/test/fixtures/glob/two.scss
@@ -1,0 +1,1 @@
+div.two { color: red; }

--- a/test/index.js
+++ b/test/index.js
@@ -18,3 +18,16 @@ test('base:importer:test', function (t) {
     t.end();
   });
 });
+
+test('base:importer:globs:test', function (t) {
+  sass.render({
+    file: 'test/fixtures/glob.scss',
+    importer: nodeSassImport
+  }, function (err, result) {
+    var css = result.css.toString();
+    t.error(err, 'should render SASS without errors');
+    t.ok(/div\.one/.test(css), 'renders one.scss');
+    t.ok(/div\.two/.test(css), 'renders two.scss');
+    t.end();
+  });
+});


### PR DESCRIPTION
See #9. This allows you to do:

```scss
@import 'components/*';
```

it does this by adding a different behavior when `urls.length > 1`. Instead of throwing an error like it does now, it joins multiple results into a `{ contents: '@import "a"; @import "b";' }` resolution.