### PR TITLE
Remove js extension from node module resolve

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+.idea
+.editorconfig
+.gitignore
+.travis.yml
+test

--- a/lib/node-sass-import.js
+++ b/lib/node-sass-import.js
@@ -44,7 +44,7 @@ var resolver = function (url, baseDir, done) {
     if (err) return done(err);
 
     // Strip the extension so .css gets evaluated properly as .scss
-    file = file.replace(/\.(sa|sc|c)ss$/, '');
+    file = file.replace(/\.(js|(sa|sc|c)ss)$/, '');
     done(null, file);
   });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "node-sass-import",
-  "version": "1.1.0",
+  "name": "@union/node-sass-import",
+  "version": "1.0.0",
   "description": "Allows usage of @include (of .scss) akin to require (of .js) in node.js",
   "bugs": "https://github.com/anarh/node-sass-import/issues",
   "author": "Emmanuel (Manny) Narh <eanarh@yahoo.com>",
@@ -45,7 +45,6 @@
     "node-sass": "^3.8.0"
   },
   "scripts": {
-    "prepublish": "npm run lint && npm test",
     "istanbul": "istanbul cover test/index.js",
     "lint": "semistandard",
     "test": "node test/index.js | tap-spec",


### PR DESCRIPTION
It is common for a npm package to specify a js file path in the `"main"` key file. If it is present, the importer is resolving to this file. It would be nice to remove the `.js` portion of the import so that if a `.css` or `.scss` file lives next to the main javascript file, we would grab that file as opposed to the js file.

I'm not sure if node-sass supports importing javascript files. If it doesn't, I don't see a down-side to implanting this change.